### PR TITLE
qualcommax: disable unused nss-drv kmods by default

### DIFF
--- a/target/linux/qualcommax/Makefile
+++ b/target/linux/qualcommax/Makefile
@@ -18,23 +18,12 @@ DEFAULT_PACKAGES += \
 	kmod-qca-nss-dp \
 	kmod-qca-nss-drv \
 	kmod-qca-nss-drv-bridge-mgr \
-	kmod-qca-nss-drv-eogremgr \
 	kmod-qca-nss-drv-gre \
 	kmod-qca-nss-drv-igs \
-	kmod-qca-nss-drv-l2tpv2 \
-	kmod-qca-nss-drv-lag-mgr \
-	kmod-qca-nss-drv-map-t \
-	kmod-qca-nss-drv-match \
-	kmod-qca-nss-drv-mirror \
 	kmod-qca-nss-drv-pppoe \
 	kmod-qca-nss-drv-pptp \
 	kmod-qca-nss-drv-qdisc \
-	kmod-qca-nss-drv-tun6rd \
-	kmod-qca-nss-drv-tunipip6 \
 	kmod-qca-nss-drv-vlan-mgr \
-	kmod-qca-nss-drv-vxlanmgr \
-	kmod-qca-nss-drv-wifi-meshmgr \
 	kmod-qca-nss-ecm \
-	kmod-qca-nss-macsec \
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
the nss-drv-* modules are not all essential, and enable "all of them" by default is not an ideal way:
especially the mesh related stuff -- mesh require certain version of ath11k firmware & NSS firmware, and  other build options, which will introduce crash/strange behavior to non-mesh builds.

refer to  [AgustinLorenzo](https://github.com/AgustinLorenzo/openwrt)'s nss and nss_mesh branch

and, anyone who **really** need certain kmods, can enable it via .config anyway.

therefore, propose to drop those nss-drv-* modules by default, and only keep the essential one's.