### PR TITLE
iproute2: NSS fixup for 6.11.0

### DIFF
--- a/package/network/utils/iproute2/patches/500-add-nssmirred.patch
+++ b/package/network/utils/iproute2/patches/500-add-nssmirred.patch
@@ -142,7 +142,7 @@
 + * print_nss_mirred()
 + *	Print information related to nssmirred action.
 + */
-+static int print_nss_mirred(const struct action_util *au, FILE * f, struct rtattr *arg)
++static int print_nss_mirred(const struct action_util *au, FILE *f, struct rtattr *arg)
 +{
 +	struct tc_nss_mirred *p;
 +	struct rtattr *tb[TCA_NSS_MIRRED_MAX + 1];
@@ -176,7 +176,7 @@
 +	if (show_stats) {
 +		if (tb[TCA_NSS_MIRRED_TM]) {
 +			struct tcf_t *tm = RTA_DATA(tb[TCA_NSS_MIRRED_TM]);
-+			print_tm(f,tm);
++			print_tm(tm);
 +		}
 +	}
 +	return 0;


### PR DESCRIPTION
ref: https://github.com/qosmio/openwrt-ipq/commit/63ae48c28211bf40c103a5b86b9630f33494b9bd