### PR TITLE
fix(qualcommax): harden first-boot uci-defaults + sysupgrade api-*.sh

### DIFF
--- a/target/linux/qualcommax/base-files/etc/uci-defaults/991_set-network.sh
+++ b/target/linux/qualcommax/base-files/etc/uci-defaults/991_set-network.sh
@@ -25,7 +25,7 @@ if [ -n "$ula_prefix" ]; then
 	uci set network.wan6.reqprefix='auto'
 	uci set network.lan.ip6assign='64'
 	uci set network.lan.ip6ifaceid='eui64'
-	uci set network.globals.packet_steering='0'
+	if lsmod 2>/dev/null | grep -q '^qca_nss_drv'; then uci set network.globals.packet_steering='0'; else uci set network.globals.packet_steering='1'; fi
 	uci del network.globals.ula_prefix
 
 	uci commit network

--- a/target/linux/qualcommax/base-files/etc/uci-defaults/992_set-nss-load.sh
+++ b/target/linux/qualcommax/base-files/etc/uci-defaults/992_set-nss-load.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
-
-#指定文件路径
+# 修正后的 NSS 启动调优
+# - sed 正则非贪婪,避免误伤多行 popen
+# - sysctl 改 sysctl.d 持久化,procd-sysctl 在合适时机应用
 FILE="/usr/share/rpcd/ucode/luci"
+[ -f "$FILE" ] && sed -i "s#popen('top -n1[^']*')#popen('/sbin/cpuusage')#" "$FILE"
 
-#添加NSS状态显示
-sed -i "s#const fd = popen('top.*')#const fd = popen('/sbin/cpuusage')#g" $FILE
-
-#锁定NSS频率
-sysctl -w dev.nss.clock.auto_scale='0'
+mkdir -p /etc/sysctl.d
+echo 'dev.nss.clock.auto_scale = 0' > /etc/sysctl.d/97-nss-lock-clock.conf
 
 exit 0

--- a/target/linux/qualcommax/base-files/etc/uci-defaults/993_set-ecm-conntrack.sh
+++ b/target/linux/qualcommax/base-files/etc/uci-defaults/993_set-ecm-conntrack.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-#指定文件路径
 FILE="/etc/sysctl.d/qca-nss-ecm.conf"
+[ -f "$FILE" ] || exit 0
 
-#修改最大连接数
-sed -i "s/nf_conntrack_max=.*/nf_conntrack_max=65535/g" $FILE
+sed -i "s/nf_conntrack_max=.*/nf_conntrack_max=65535/" "$FILE"
 
 exit 0

--- a/target/linux/qualcommax/base-files/etc/uci-defaults/999_auto-restart.sh
+++ b/target/linux/qualcommax/base-files/etc/uci-defaults/999_auto-restart.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-/etc/init.d/network restart
-/etc/init.d/odhcpd restart
-/etc/init.d/rpcd restart
-
-exit 0

--- a/target/linux/qualcommax/base-files/lib/functions/bootconfig.sh
+++ b/target/linux/qualcommax/base-files/lib/functions/bootconfig.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 
 PART_SIZE=20

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-alfa.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-alfa.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-asus.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-asus.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-buffalo.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-buffalo.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-elecom.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-elecom.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-glinet.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-glinet.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-linksys.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-linksys.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 . /lib/functions/bootconfig.sh

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-qihoo.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-qihoo.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 . /lib/functions/bootconfig.sh

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-tcl.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-tcl.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 . /lib/functions/bootconfig.sh

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-tplink.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-tplink.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-xiaomi.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-xiaomi.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 

--- a/target/linux/qualcommax/base-files/lib/upgrade/api-yuncore.sh
+++ b/target/linux/qualcommax/base-files/lib/upgrade/api-yuncore.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 . /lib/functions.sh
 . /lib/upgrade/common.sh
 


### PR DESCRIPTION
## What this PR does

Fixes a few latent issues in the `target/linux/qualcommax/base-files` startup chain that affect AX6 / IPQ807x / IPQ60xx boards on first boot and on sysupgrade.

## Issues fixed

1. **11 `lib/upgrade/api-*.sh` files + `lib/functions/bootconfig.sh` lack `#!/bin/sh`**
   `shellcheck` flags them with SC2148. They are sourced by sysupgrade so it usually works, but bare execution / static analysis breaks. Adds the shebang.

2. **`uci-defaults/999_auto-restart.sh` restarts `network` / `odhcpd` / `rpcd` during uci-defaults boot phase**
   This is a known anti-pattern: procd hasn't fully come up yet, restarting these services here is racy and serves no purpose because procd will start them in the proper order anyway. The script is deleted.

3. **`uci-defaults/992_set-nss-load.sh`**
   - The `sed` regex `popen('top.*')` is greedy and risks damaging multi-line `popen` calls in `/usr/share/rpcd/ucode/luci`. Made non-greedy and bounded.
   - `sysctl -w dev.nss.clock.auto_scale='0'` runs in uci-defaults phase — but `qca-nss-drv` may not be loaded yet at that point, so the sysctl fails silently. Moved to `/etc/sysctl.d/97-nss-lock-clock.conf` so `procd-sysctl` applies it at the correct moment.

4. **`uci-defaults/993_set-ecm-conntrack.sh` silently fails when target file missing**
   Adds `[ -f "$FILE" ] || exit 0` guard so non-NSS builds don't generate noisy `sed` errors.

5. **`uci-defaults/991_set-network.sh` always sets `packet_steering=0`**
   This assumes NSS is loaded. If `qca_nss_drv` failed to load (kernel mismatch, hardware variant, etc.), packet_steering=0 plus no NSS = traffic single-cores and throughput collapses. Adds a fallback to `=1` when the module isn't loaded.

## Testing

- `shellcheck -S error` clean on the touched files
- `bash -n` on each rewritten script passes
- Manual review: matches OpenWrt sysupgrade conventions

## Compatibility

No DT / image / package list changes. Only modifies init scripts under `target/linux/qualcommax/base-files/`. Safe to backport to any branch that has this layout.
