### PR TITLE
wifi-scripts: use per-interface hostapd control path

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -546,7 +546,7 @@ function iface_interworking(config) {
 }
 
 export function generate(interface, data, config, vlans, stas, phy_features) {
-	config.ctrl_interface = '/var/run/hostapd';
+	config.ctrl_interface = `/var/run/hostapd/${interface}`;
 
 	config.start_disabled = data.ap_start_disabled;
 	iface_setup(config);


### PR DESCRIPTION
Set hostapd ctrl_interface to a per-interface directory under /var/run/hostapd instead of the shared parent directory. This avoids permission denied errors when hostapd tears down AP interfaces while running as the network user.