### PR TITLE
fix qnss failes when build all kernel mods

### DIFF
--- a/package/qca-nss/qca-ssdk/Makefile
+++ b/package/qca-nss/qca-ssdk/Makefile
@@ -29,7 +29,10 @@ define KernelPackage/qca-ssdk
   TITLE:=Qualcomm SSDK switch driver
   DEPENDS:=@TARGET_qualcommax \
 	+kmod-dsa
-  FILES:=$(PKG_BUILD_DIR)/build/bin/qca-ssdk.ko
+  FILES:=$(PKG_BUILD_DIR)/build/bin/qca-ssdk.ko \
+  $(LINUX_DIR)/drivers/net/mdio/mdio-bitbang.ko \
+  $(LINUX_DIR)/drivers/net/mdio/mdio-i2c.ko
+
   AUTOLOAD:=$(call AutoLoad,30,qca-ssdk)
 endef
 

--- a/package/qca-nss/qca-ssdk/patches/0100-mido-i2c-qcom-compat.patch
+++ b/package/qca-nss/qca-ssdk/patches/0100-mido-i2c-qcom-compat.patch
@@ -1,0 +1,18 @@
+--- a/src/init/ssdk_dts.c
++++ b/src/init/ssdk_dts.c
+@@ -38,6 +38,16 @@
+ #include <linux/of.h>
+ #include <linux/of_mdio.h>
+ #include <linux/of_platform.h>
++
++/* Compat: Linux 6.18+ removed MIDO_I2C_QCOM from kernel headers */
++#ifndef MIDO_I2C_QCOM
++#ifdef MDIO_I2C_C45
++#define MIDO_I2C_QCOM MDIO_I2C_C45
++#else
++#define MIDO_I2C_QCOM 0
++#endif
++#endif
++
+ #if IS_ENABLED(CONFIG_MDIO_I2C)
+ #include <linux/mdio/mdio-i2c.h>


### PR DESCRIPTION
我全部勾选内核kmods模块后，qnss的ssdk报错。这个patch可以修复报的错。